### PR TITLE
Solve lint errors

### DIFF
--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache-libgit2
         with:
-          path: /usr/local/lib/libgit2.so.*
+          path: /opt/local/lib/libgit2.so.*
           key: ${{ runner.os }}-libgit2-1.2.0
 
       - uses: actions/checkout@v2
@@ -24,6 +24,8 @@ jobs:
 
       - name: "Install libgit2 from sources"
         run: ./hack/ubuntu/libgit2.sh
+        env:
+          LIBGIT_PREFIX: /opt/local
         if: steps.cache-libgit2.outputs.cache-hit != 'true'
 
       - uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           path: /usr/local/lib/libgit2.so.*
           key: ${{ runner.os }}-libgit2-1.2.0
-      
+
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
@@ -25,9 +25,11 @@ jobs:
       - name: "Install libgit2 from sources"
         run: ./hack/ubuntu/libgit2.sh
         if: steps.cache-libgit2.outputs.cache-hit != 'true'
-      
+
+      - uses: golangci/golangci-lint-action@v2
+
       - run: make test
-      
+
       - uses: codecov/codecov-action@v2
         with:
           verbose: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,3 @@
 run:
   concurrency: 4
-  
+  timeout: 10m  

--- a/pkg/chartstreams/chart_provider_fake.go
+++ b/pkg/chartstreams/chart_provider_fake.go
@@ -28,7 +28,17 @@ func (f *FakeChartProvider) GetIndexFile() *helmrepo.IndexFile {
 		Name:       "chart",
 		Version:    "0.0.1",
 	}
-	indexFile.Add(metadata, "chart.tgz", baseURL, "digest")
+
+	// NOTE(isutton): I was inclined to not ignore the error and
+	// replace with the code below, but it didn't feel important
+	// enough to bother for now.
+	_ = indexFile.MustAdd(metadata, "chart.tgz", baseURL, "digest")
+
+	// err := indexFile.MustAdd(metadata, "chart.tgz", baseURL, "digest")
+	// if err != nil {
+	// 	panic(err)
+	// }
+
 	indexFile.SortEntries()
 	return indexFile
 }

--- a/pkg/chartstreams/git_repo.go
+++ b/pkg/chartstreams/git_repo.go
@@ -92,7 +92,10 @@ func (g *GitRepo) CheckoutCommit(branch string, c *git.Commit) error {
 
 	head := fmt.Sprintf("refs/heads/%s", branch)
 	log.Debugf("Setting head as '%s' for branch '%s'", head, branch)
-	g.r.SetHead(head)
+	err = g.r.SetHead(head)
+	if err != nil {
+		return err
+	}
 	return g.r.CheckoutHead(checkoutOpts)
 }
 
@@ -120,7 +123,10 @@ func (g *GitRepo) checkoutBranch(branch string) error {
 
 	reference := fmt.Sprintf("refs/heads/%s", branch)
 	log.Debugf("Setting reference '%s' on branch '%s'", reference, branch)
-	g.r.SetHead(reference)
+	err = g.r.SetHead(reference)
+	if err != nil {
+		return err
+	}
 	_, err = g.r.References.Create(reference, c.Id(), true, branch)
 	return err
 }
@@ -179,7 +185,10 @@ func (g *GitRepo) ModifiedFiles(c *git.Commit, tree *git.Tree) ([]string, error)
 				"creating diff between parent's commit-id %q and %q: %w",
 				parentID.String(), c.Id().String(), err)
 		}
-		defer diff.Free()
+		defer func() {
+			// there isn't anything useful to do.
+			_ = diff.Free()
+		}()
 
 		_ = diff.ForEach(func(f git.DiffDelta, p float64) (git.DiffForEachHunkCallback, error) {
 			modified = append(modified, f.OldFile.Path)


### PR DESCRIPTION
This change solves the lint errors raised by the default golangci-lint
configuration.