### PR TITLE
Migrate build and tests from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -1,6 +1,7 @@
 name: chart-streams
 on: [push]
 
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -8,6 +9,8 @@ env:
 
 jobs:
   build-and-test:
+    environment:
+      name: build
     runs-on: ubuntu-latest
     services:
       registry:

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -30,6 +30,6 @@ jobs:
           push: true
           file: Dockerfile.dev
           tags: ${{ env.IMAGE_DEV_TAG }}
-      - run: make devcontainer-run CODECOV_TOKEN="$CODECOV_TOKEN" IMAGE_DEV_TAG="$IMAGE_DEV_TAG" DEVCONTAINER_ARGS='make CODECOV_TOKEN=$CODECOV_TOKEN vendor test codecov'
+      - run: make devcontainer-run CODECOV_TOKEN="$CODECOV_TOKEN" IMAGE_DEV_TAG="$IMAGE_DEV_TAG" DEVCONTAINER_ARGS="make CODECOV_TOKEN=\"$CODECOV_TOKEN\" vendor test codecov"
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -1,5 +1,10 @@
 name: chart-streams
 on: [push]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -10,6 +15,13 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v2
+
+      # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions
+      - uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v1
         with:
           driver-opts: network=host

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -30,6 +30,6 @@ jobs:
           push: true
           file: Dockerfile.dev
           tags: ${{ env.IMAGE_DEV_TAG }}
-      - run: make devcontainer-run CODECOV_TOKEN="$CODECOV_TOKEN" IMAGE_DEV_TAG="$IMAGE_DEV_TAG" DEVCONTAINER_ARGS='make CODECOV_TOKEN=$CODECOV_TOKEN test codecov'
+      - run: make devcontainer-run CODECOV_TOKEN="$CODECOV_TOKEN" IMAGE_DEV_TAG="$IMAGE_DEV_TAG" DEVCONTAINER_ARGS='make CODECOV_TOKEN=$CODECOV_TOKEN vendor test codecov'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -4,6 +4,7 @@ on: [push]
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  IMAGE_DEV_TAG: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
 jobs:
   build-and-test:
@@ -31,7 +32,8 @@ jobs:
           context: .
           push: true
           file: Dockerfile.dev
-          tags: ghcr.io/isutton/chart-streams-dev:latest
-      - run: make devcontainer-run IMAGE_DEV_TAG="ghcr.io/isutton/chart-streams-dev:latest" DEVCONTAINER_ARGS="make CODECOV_TOKEN='${CODECOV_TOKEN}' build test codecov"
+          tags: ${{ env.IMAGE_DEV_TAG }}
+      - run: make devcontainer-run IMAGE_DEV_TAG="$IMAGE_DEV_TAG" DEVCONTAINER_ARGS="make build test codecov"
         env:
-          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+          GITHUB_SHA: ${{ github.sha }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -12,11 +12,6 @@ jobs:
     environment:
       name: build
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
     steps:
       - uses: actions/checkout@v2
 
@@ -28,7 +23,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v1
         with:
-          driver-opts: network=host
           install: true
       - uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -1,0 +1,12 @@
+name: chart-streams
+on: [push]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+      - run: make devcontainer-image
+      - run: make devcontainer-run DEVCONTAINER_ARGS='make build test codecov'

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -1,6 +1,9 @@
 name: chart-streams
-on: [push]
-
+on:
+  push:
+  pull_request:
+    branches:
+      - master
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -19,7 +19,7 @@ jobs:
           context: .
           push: true
           file: Dockerfile.dev
-          tags: localhost:5000/otaviof/chart-streams-dev:latest
-      - run: make devcontainer-run IMAGE_DEV_TAG='localhost:5000/otaviof/chart-streams-dev:latest' DEVCONTAINER_ARGS="make CODECOV_TOKEN='${CODECOV_TOKEN}' build test codecov"
+          tags: ghcr.io/isutton/chart-streams-dev:latest
+      - run: make devcontainer-run IMAGE_DEV_TAG="ghcr.io/isutton/chart-streams-dev:latest" DEVCONTAINER_ARGS="make CODECOV_TOKEN='${CODECOV_TOKEN}' build test codecov"
         env:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -3,10 +3,23 @@ on: [push]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
         with:
+          driver-opts: network=host
           install: true
-      - run: make devcontainer-image
-      - run: make devcontainer-run DEVCONTAINER_ARGS='make build test codecov'
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          file: Dockerfile.dev
+          tags: localhost:5000/otaviof/chart-streams-dev:latest
+      - run: make devcontainer-run IMAGE_DEV_TAG='localhost:5000/otaviof/chart-streams-dev:latest' DEVCONTAINER_ARGS="make CODECOV_TOKEN='${CODECOV_TOKEN}' build test codecov"
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -30,6 +30,6 @@ jobs:
           push: true
           file: Dockerfile.dev
           tags: ${{ env.IMAGE_DEV_TAG }}
-      - run: make devcontainer-run CODECOV_TOKEN="$CODECOV_TOKEN" IMAGE_DEV_TAG="$IMAGE_DEV_TAG" DEVCONTAINER_ARGS="make build test codecov"
+      - run: make devcontainer-run CODECOV_TOKEN="$CODECOV_TOKEN" IMAGE_DEV_TAG="$IMAGE_DEV_TAG" DEVCONTAINER_ARGS='make CODECOV_TOKEN=$CODECOV_TOKEN test codecov'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -5,7 +5,7 @@ on: [push]
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  IMAGE_DEV_TAG: ghcr.io/${{ github.repository }}:latest
+  IMAGE_DEV_TAG: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
 jobs:
   build-and-test:

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -33,6 +33,6 @@ jobs:
           push: true
           file: Dockerfile.dev
           tags: ${{ env.IMAGE_DEV_TAG }}
-      - run: make devcontainer-run IMAGE_DEV_TAG="$IMAGE_DEV_TAG" DEVCONTAINER_ARGS="make build test codecov"
+      - run: make devcontainer-run CODECOV_TOKEN="$CODECOV_TOKEN" IMAGE_DEV_TAG="$IMAGE_DEV_TAG" DEVCONTAINER_ARGS="make build test codecov"
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -4,7 +4,7 @@ on: [push]
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  IMAGE_DEV_TAG: ghcr.io/${{ github.repository }}:${{ github.sha }}
+  IMAGE_DEV_TAG: ghcr.io/${{ github.repository }}:latest
 
 jobs:
   build-and-test:
@@ -35,5 +35,4 @@ jobs:
           tags: ${{ env.IMAGE_DEV_TAG }}
       - run: make devcontainer-run IMAGE_DEV_TAG="$IMAGE_DEV_TAG" DEVCONTAINER_ARGS="make build test codecov"
         env:
-          GITHUB_SHA: ${{ github.sha }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
----
-services:
-  - docker
-install:
-  - make devcontainer-image
-  - make devcontainer-run DEVCONTAINER_ARGS='go env'
-script:
-  - make devcontainer-run DEVCONTAINER_ARGS='make build test codecov'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 ---
-language: go
 services:
   - docker
-go:
-  - 1.14.x
 install:
   - make devcontainer-image
+  - make devcontainer-run DEVCONTAINER_ARGS='go env'
 script:
   - make devcontainer-run DEVCONTAINER_ARGS='make build test codecov'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
 go:
   - 1.14.x
 install:
-  - make vendor
   - make devcontainer-image
 script:
   - make devcontainer-run DEVCONTAINER_ARGS='make build test codecov'

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,3 +7,5 @@ WORKDIR  /src
 RUN yum install --assumeyes make && \
     make devcontainer-deps && \
     rm -rf /src
+
+RUN mkdir -p -m 0777 /build

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ devcontainer-run:
 		--rm \
 		--interactive \
 		--tty \
-		--env TMPDIR=/src \
+		--tmpfs="/tmp" \
 		--volume="${PWD}:/src/$(APP)" \
 		--workdir="/src/$(APP)" \
 		$(IMAGE_DEV_TAG) $(DEVCONTAINER_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -76,14 +76,7 @@ devcontainer-image:
 
 # execute devcontainer mounting local project directory
 devcontainer-run:
-	docker run \
-		--rm \
-		--interactive \
-		--tty \
-		--mount type=tmpfs,destination=/tmp,tmpfs-mode=1770 \
-		--volume="${PWD}:/src/$(APP)" \
-		--workdir="/src/$(APP)" \
-		$(IMAGE_DEV_TAG) $(DEVCONTAINER_ARGS)
+	./hack/devcontainer-run.sh
 
 # start a bash shell in devcontainer
 devcontainer-exec:

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ devcontainer-run:
 		--rm \
 		--interactive \
 		--tty \
+		--env TMPDIR=/src \
 		--volume="${PWD}:/src/$(APP)" \
 		--workdir="/src/$(APP)" \
 		$(IMAGE_DEV_TAG) $(DEVCONTAINER_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ devcontainer-run:
 		--rm \
 		--interactive \
 		--tty \
-		--tmpfs="/tmp" \
+		--mount type=tmpfs,destination=/tmp,tmpfs-mode=1770 \
 		--volume="${PWD}:/src/$(APP)" \
 		--workdir="/src/$(APP)" \
 		$(IMAGE_DEV_TAG) $(DEVCONTAINER_ARGS)

--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@
     <a alt="GoDoc" href="https://godoc.org/github.com/otaviof/chart-streams/pkg/chartstreams">
         <img alt="GoDoc Reference" src="https://godoc.org/github.com/otaviof/chart-streams/pkg/chartstreams?status.svg">
     </a>
-    <a alt="CI Status" href="https://travis-ci.com/otaviof/chart-streams">
-        <img alt="CI Status" src="https://travis-ci.com/otaviof/chart-streams.svg?branch=master">
+    <a href="https://github.com/isutton/chart-streams/actions/workflows/chart-streams.yaml">
+        <img alt="GitHub Status" src="https://github.com/isutton/chart-streams/actions/workflows/chart-streams.yaml/badge.svg">
+    </a>
     </a>
     <a alt="Image Build Status" href="https://quay.io/repository/otaviof/chart-streams">
         <img alt="Image Build Status" src="https://quay.io/repository/otaviof/chart-streams/status">
     </a>
 </p>
+
 
 # `chart-streams`
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ helm install grafana cs/grafana:2.0.2-revert-10682-master-fa4468c8
 
 ## Semantic Versioning
 
-Git repository tree is transversed commit-by-commit starting from latest. On transversing the
+Git repository tree is traversed commit-by-commit starting from latest. On traversing the
 commits `chart-streams` will identify from which branch each change is coming from, and with this
 information publish stable and development versions of Helm-Charts, adding
-[semanatic versioning][semver] representation [understood by Helm][helmsemver].
+[semantic versioning][semver] representation [understood by Helm][helmsemver].
 
 Chart versions are ultimately defined by regular `Chart.yaml`, however it's enriched when change is
 located in a branch other than `master`. In `master` the exact version present in `Chart.yaml` is
@@ -151,7 +151,7 @@ In order to behave as a Helm-Charts repository, `chart-streams` exposes the foll
 
 ### `/index.yaml`
 
-Dinamically render `index.yaml` payload, representing actual Git repository data as Helm-Charts
+Dynamically render `index.yaml` payload, representing actual Git repository data as Helm-Charts
 repository index. Helm clients are frequently downloading this payload in order to check which charts
 and versions are available in the repository.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <a alt="GoDoc" href="https://godoc.org/github.com/otaviof/chart-streams/pkg/chartstreams">
         <img alt="GoDoc Reference" src="https://godoc.org/github.com/otaviof/chart-streams/pkg/chartstreams?status.svg">
     </a>
-    <a href="https://github.com/isutton/chart-streams/actions/workflows/chart-streams.yaml">
+    <a alt="GitHub Status" href="https://github.com/isutton/chart-streams/actions/workflows/chart-streams.yaml">
         <img alt="GitHub Status" src="https://github.com/isutton/chart-streams/actions/workflows/chart-streams.yaml/badge.svg">
     </a>
     </a>

--- a/hack/codecov.sh
+++ b/hack/codecov.sh
@@ -25,7 +25,7 @@ function die() {
 }
 
 function download_codecov() {
-    curl --silent --output ${CODECOV_BIN} https://codecov.io/bash
+    curl --silent --output ${CODECOV_BIN} https://codecov.io/env
     chmod +x ${CODECOV_BIN}
 }
 

--- a/hack/devcontainer-run.sh
+++ b/hack/devcontainer-run.sh
@@ -4,7 +4,7 @@ docker run \
     --rm \
     --interactive \
     --env GOTMPDIR=/build \
-    --env CODECOV_TOKEN="${CODECOV_TOKEN}"
+    --env CODECOV_TOKEN="${CODECOV_TOKEN}" \
     --volume="${PWD}:/src/${APP}" \
     --workdir="/src/${APP}" \
     ${IMAGE_DEV_TAG} ${DEVCONTAINER_ARGS}

--- a/hack/devcontainer-run.sh
+++ b/hack/devcontainer-run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+TMPDIR=$(mktemp -d)
+
+docker run \
+    --rm \
+    --interactive \
+    --tty \
+    --mount type=bind,source="${TMPDIR}",destination=/tmp \
+    --volume="${PWD}:/src/${APP}" \
+    --workdir="/src/${APP}" \
+    ${IMAGE_DEV_TAG} ${DEVCONTAINER_ARGS}
+
+rm -fr "${TMPDIR}"

--- a/hack/devcontainer-run.sh
+++ b/hack/devcontainer-run.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 
-TMPDIR=$(mktemp -d)
-
 docker run \
     --rm \
     --interactive \
     --tty \
-    --mount type=bind,source="${TMPDIR}",destination=/tmp \
+    --env GOTMPDIR=/build \
     --volume="${PWD}:/src/${APP}" \
     --workdir="/src/${APP}" \
     ${IMAGE_DEV_TAG} ${DEVCONTAINER_ARGS}
 
-rm -fr "${TMPDIR}"

--- a/hack/devcontainer-run.sh
+++ b/hack/devcontainer-run.sh
@@ -4,6 +4,7 @@ docker run \
     --rm \
     --interactive \
     --env GOTMPDIR=/build \
+    --env CODECOV_TOKEN="${CODECOV_TOKEN}"
     --volume="${PWD}:/src/${APP}" \
     --workdir="/src/${APP}" \
     ${IMAGE_DEV_TAG} ${DEVCONTAINER_ARGS}

--- a/hack/devcontainer-run.sh
+++ b/hack/devcontainer-run.sh
@@ -3,7 +3,6 @@
 docker run \
     --rm \
     --interactive \
-    --tty \
     --env GOTMPDIR=/build \
     --volume="${PWD}:/src/${APP}" \
     --workdir="/src/${APP}" \


### PR DESCRIPTION
This change list naively migrates CI from Travis CI to GitHub Actions.

There is still work related to separate the dev container image into a different workflow to optimize the CI time.

For the codecov target to work, an environment called `build` with the secret `CODECOV_TOKEN` should be created in the project settings as well with the token obtained in codecov.io.