### PR TITLE
Properly cache libgit2 installed from sources

### DIFF
--- a/.github/workflows/chart-streams.yaml
+++ b/.github/workflows/chart-streams.yaml
@@ -11,12 +11,12 @@ jobs:
       name: build
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/cache@v2
         id: cache-libgit2
         with:
           path: /opt/libgit2
           key: ${{ runner.os }}-${{ hashFiles('hack/ubuntu/libgit2.sh') }}
-      - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16.8'


### PR DESCRIPTION
This change list only fixes the order of the checkout and cache actions, where checkout should happen before the cache since the `hack/ubuntu/libgit2.sh` digest is used to compose the key, with the intention of rebuilding it whenever the file content changes.