### PR TITLE
Introduce --force-clone command line option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMMON_FLAGS ?= -v -mod=vendor
 CHARTS_REPO_ARCHIVE ?= test/charts-repo.tar.gz
 CHARTS_REPO_DIR ?= $(OUTPUT_DIR)/charts-repo
 
-TEST_TIMEOUT ?= 3m
+TEST_TIMEOUT ?= 10m
 TEST_FLAGS ?= -failfast -timeout=$(TEST_TIMEOUT)
 
 UNIT_TEST_TARGET ?= ./cmd/... ./pkg/...

--- a/cmd/chartstreams/serve.go
+++ b/cmd/chartstreams/serve.go
@@ -26,6 +26,7 @@ func init() {
 	flags.String("listen-addr", ":8080", "Address to listen")
 	flags.String("working-dir", "/var/lib/chart-streams", "Git repository working directory")
 	flags.String("log-level", "info", "Log verbosity level (error, warn, info, debug, trace)")
+	flags.Bool("force-clone", false, "destroys working-dir and clones the repository")
 
 	rootCmd.AddCommand(serveCmd)
 	bindViperFlags(flags)
@@ -40,6 +41,7 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 		CloneDepth:  viper.GetInt("clone-depth"),
 		ListenAddr:  viper.GetString("listen-addr"),
 		RelativeDir: viper.GetString("relative-dir"),
+		ForceClone:  viper.GetBool("force-clone"),
 	}
 
 	log.Printf("Starting server with config: '%#v'", cfg)

--- a/pkg/chartstreams/config.go
+++ b/pkg/chartstreams/config.go
@@ -6,4 +6,5 @@ type Config struct {
 	RelativeDir string // relative directory in repository
 	CloneDepth  int    // number of commits to load from history
 	ListenAddr  string // address to listen on (address:port)
+	ForceClone  bool   // destroy the destination directory before cloning
 }

--- a/pkg/chartstreams/git_repo.go
+++ b/pkg/chartstreams/git_repo.go
@@ -325,14 +325,8 @@ func NewGitRepo(cfg *Config, workdingDir string) (*GitRepo, error) {
 			return nil, fmt.Errorf("cloning repository '%s' on '%s': %w", cfg.RepoURL, workdingDir, err)
 		}
 
-		defaultRemote := "origin"
-		r, err := repo.Remotes.Lookup(defaultRemote)
-		if err != nil {
-			return nil, fmt.Errorf("looking up remote '%s': %w", defaultRemote, err)
-		}
-
-		if r.Url() != cfg.RepoURL {
-			return nil, fmt.Errorf("expected repository url '%s', got '%s'", cfg.RepoURL, r.Url())
+		if err := assertRemoteUrl(repo, "origin", cfg.RepoURL); err != nil {
+			log.Errorf("asserting remote '%s' url: %s", cfg.RepoURL, err)
 		}
 
 		log.Infof("Repository found in '%s' opened successfully", workdingDir)
@@ -366,4 +360,15 @@ func NewGitRepo(cfg *Config, workdingDir string) (*GitRepo, error) {
 		head:       head.Target(),
 		branches:   branches,
 	}, nil
+}
+
+func assertRemoteUrl(repo *git.Repository, name string, expected string) error {
+	r, err := repo.Remotes.Lookup(name)
+	if err != nil {
+		return fmt.Errorf("looking up remote '%s': %w", name, err)
+	}
+	if r.Url() != expected {
+		return fmt.Errorf("expected repository url '%s', got '%s'", expected, r.Url())
+	}
+	return nil
 }

--- a/pkg/chartstreams/git_repo_test.go
+++ b/pkg/chartstreams/git_repo_test.go
@@ -36,6 +36,10 @@ func TestGitRepo_NewGitRepoUpstream(t *testing.T) {
 	r, err = NewGitRepo(cfg, tempDir)
 	require.NoError(t, err, "re-opening working-dir after successful clone")
 
+	cfg.ForceClone = true
+	_, err = NewGitRepo(cfg, tempDir)
+	require.NoError(t, err, "forcing clone into working-dir")
+
 	_ = os.RemoveAll(tempDir)
 }
 
@@ -59,6 +63,10 @@ func TestGitRepo_NewGitRepoLocal(t *testing.T) {
 
 	_, err = NewGitRepo(cfg, tempDir)
 	require.NoError(t, err, "re-opening working-dir after successful clone")
+
+	cfg.ForceClone = true
+	_, err = NewGitRepo(cfg, tempDir)
+	require.NoError(t, err, "forcing clone into working-dir")
 
 	_ = os.RemoveAll(tempDir)
 }

--- a/pkg/chartstreams/git_repo_test.go
+++ b/pkg/chartstreams/git_repo_test.go
@@ -33,6 +33,9 @@ func TestGitRepo_NewGitRepoUpstream(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	r, err = NewGitRepo(cfg, tempDir)
+	require.NoError(t, err, "re-opening working-dir after successful clone")
+
 	_ = os.RemoveAll(tempDir)
 }
 
@@ -53,6 +56,9 @@ func TestGitRepo_NewGitRepoLocal(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+
+	_, err = NewGitRepo(cfg, tempDir)
+	require.NoError(t, err, "re-opening working-dir after successful clone")
 
 	_ = os.RemoveAll(tempDir)
 }


### PR DESCRIPTION
This change list introduces the `--force-clone` command line option to 
ignore the contents of the directory informed by `--working-dir` and 
perform a clone operation after removing the existing directory.