### PR TITLE
Serve tarballs directly from Git index

### DIFF
--- a/pkg/chartstreams/chart_provider.go
+++ b/pkg/chartstreams/chart_provider.go
@@ -3,6 +3,7 @@ package chartstreams
 import (
 	"fmt"
 
+	git "github.com/libgit2/git2go/v31"
 	helmrepo "helm.sh/helm/v3/pkg/repo"
 )
 
@@ -45,6 +46,22 @@ func (g *GitChartProvider) Initialize() error {
 	return nil
 }
 
+func (g *GitChartProvider) BuildPackage(
+	path string,
+	info *CommitInfo,
+	commit *git.Commit,
+) (*Package, error) {
+	files, err := g.gitRepo.GetFilesFromCommit(commit, path)
+	if err != nil {
+		return nil, fmt.Errorf("getting files from commit: %w", err)
+	}
+	p, err := LoadFiles(files, info.Time)
+	if err != nil {
+		return nil, fmt.Errorf("loading files from index: %w", err)
+	}
+	return p, nil
+}
+
 // GetChart returns a chart Package for the given chart name and version.
 func (g *GitChartProvider) GetChart(name string, version string) (*Package, error) {
 	commitInfo := g.indexBuilder.GetChartCommitInfo(name, version)
@@ -56,17 +73,14 @@ func (g *GitChartProvider) GetChart(name string, version string) (*Package, erro
 	if err != nil {
 		return nil, fmt.Errorf("looking up commit %q: %w", commitInfo.ID, err)
 	}
-	if err = g.gitRepo.CheckoutCommit(commitInfo.Revision, c); err != nil {
-		return nil, fmt.Errorf("checking out commit %q: %w", commitInfo.ID, err)
+
+	p, err := g.BuildPackage(name, commitInfo, c)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating package in %q: %w", name, err)
 	}
 
-	absPath := g.indexBuilder.ChartAbsPath(name)
-	p, err := NewPackage(absPath, commitInfo.Time)
-	if err != nil {
-		return nil, fmt.Errorf("instantiating package in %q: %w", absPath, err)
-	}
 	if err = p.Build(); err != nil {
-		return nil, fmt.Errorf("building package for %q: %w", absPath, err)
+		return nil, fmt.Errorf("building package for %q: %w", name, err)
 	}
 	return p, nil
 }

--- a/pkg/chartstreams/package.go
+++ b/pkg/chartstreams/package.go
@@ -90,6 +90,20 @@ func (p *Package) Build() error {
 	return bw.Flush()
 }
 
+// LoadFiles creates a Package using the given in-memory files.
+func LoadFiles(files []*loader.BufferedFile, t *time.Time) (*Package, error) {
+	chart, err := loader.LoadFiles(files)
+	if err != nil {
+		return nil, fmt.Errorf("loading chart from in-memory files: %w", err)
+	}
+	return &Package{
+		dir:   "in-memory",
+		t:     t,
+		chart: chart,
+		b:     bytes.NewBuffer([]byte{}),
+	}, nil
+}
+
 // NewPackage instantiate a package by inspecting directory and loading the chart.
 func NewPackage(dir string, t *time.Time) (*Package, error) {
 	chart, err := loader.LoadDir(dir)


### PR DESCRIPTION
This change list builds the chart tarball directly from the Git index, without checking out the revision in the working directory.

The next step is to build the `index.yaml` endpoint from the Git index as well; although related, it'd be too much to include both in the same pull request.